### PR TITLE
Add optional SDL compile-time switch

### DIFF
--- a/ImGuiColorTextEdit.cpp
+++ b/ImGuiColorTextEdit.cpp
@@ -1,5 +1,11 @@
+#ifndef IMGUICTE_USE_SDL2
+#define IMGUICTE_USE_SDL2 0
+#endif
+
+#if IMGUICTE_USE_SDL2
 #include <SDL2/SDL_events.h>
 #include <SDL2/SDL_keyboard.h>
+#endif
 #include <algorithm>
 #include <functional>
 #include <chrono>


### PR DESCRIPTION
## Summary
- allow building without SDL by guarding SDL includes behind IMGUICTE_USE_SDL2

## Testing
- `g++ -std=c++17 -DIMGUI_DEFINE_MATH_OPERATORS -DIMGUICTE_USE_SDL2=1 -c ImGuiColorTextEdit.cpp` *(fails: no matching function for call to IsKeyPressed(SDL_Scancode&))*

------
https://chatgpt.com/codex/tasks/task_e_68b4fb36a558832c8b1ec58217b22f59