### PR TITLE
Support multiple comment markers

### DIFF
--- a/ImGuiColorTextEdit.h
+++ b/ImGuiColorTextEdit.h
@@ -275,7 +275,8 @@ public:
         Keywords mKeywords;
         Identifiers mIdentifiers;
         Identifiers mPreprocIdentifiers;
-        std::string mCommentStart, mCommentEnd, mSingleLineComment;
+        std::vector<std::string> single_line_comments;
+        std::vector<std::pair<std::string,std::string>> block_comments;
         char mPreprocChar;
         bool mAutoIndentation;
 


### PR DESCRIPTION
## Summary
- allow multiple comment syntaxes by storing single-line and block markers in vectors
- adjust comment colorization to iterate over all configured markers
- update language definitions to populate new comment marker lists

## Testing
- `apt-get install -y libimgui-dev`
- `g++ -std=c++17 -I/usr/include/imgui -c ImGuiColorTextEdit.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68b51c8e06b8832c9860ff17de0894be