### PR TITLE
docs: add json editor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,129 @@ The code is (still) work in progress, please report if you find any issues.
 | JSONC | `static const LanguageDefinition& JSONC();` |
 | JSONWithHash | `static const LanguageDefinition& JSONWithHash();` |
 
+# JSON editor example
+
+The snippet below demonstrates how to embed **ImGuiColorTextEdit** in a JSON tool and how to tweak the color palette.  The code is condensed for clarity but shows a typical integration pattern.
+
+```cpp
+#include "ImGuiColorTextEdit.h"
+
+// Create the editor and enable JSON syntax
+TextEditor editor;
+auto lang = TextEditor::LanguageDefinition::JSON();
+editor.SetLanguageDefinition(lang);
+
+// Optional: create a custom color palette based on the dark theme
+TextEditor::Palette customPalette = TextEditor::GetDarkPalette();
+customPalette[(int)TextEditor::PaletteIndex::Keyword] = ImVec4(0.86f, 0.40f, 0.24f, 1.0f); // keywords
+customPalette[(int)TextEditor::PaletteIndex::String]  = ImVec4(0.90f, 0.76f, 0.18f, 1.0f); // strings
+editor.SetPalette(customPalette);
+
+// --- main render loop ---
+const float window_width  = window.getSize().x;
+const float window_height = window.getSize().y;
+auto cpos = editor.GetCursorPosition();
+
+ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+ImGui::SetNextWindowSize(ImVec2(window_width, window_height - indent_basement), ImGuiCond_Always);
+ImGui::Begin("CryptoJsonMainMenu", nullptr,
+    ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
+    ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar |
+    ImGuiWindowFlags_MenuBar);
+
+if (ImGui::BeginMenuBar()) {
+    if (ImGui::BeginMenu("File")) {
+        if (ImGui::MenuItem("Open"))
+            file_dialog_open = true;
+        if (ImGui::MenuItem("Save", nullptr, false, cj_config.is_init)) {
+            auto text = editor.GetText();
+            // save text to file
+        }
+        if (ImGui::MenuItem("Save as..."))
+            file_dialog_save = true;
+        if (ImGui::MenuItem("Quit", "Alt-F4"))
+            break;
+        ImGui::EndMenu();
+    }
+    if (ImGui::BeginMenu("Edit")) {
+        bool readOnly = editor.IsReadOnly();
+        if (ImGui::MenuItem("Read-only mode", nullptr, &readOnly))
+            editor.SetReadOnly(readOnly);
+        ImGui::Separator();
+
+        if (ImGui::MenuItem("Undo", "ALT-Backspace", nullptr, !readOnly && editor.CanUndo()))
+            editor.Undo();
+        if (ImGui::MenuItem("Redo", "Ctrl-Y", nullptr, !readOnly && editor.CanRedo()))
+            editor.Redo();
+
+        ImGui::Separator();
+
+        if (ImGui::MenuItem("Copy", "Ctrl-C", nullptr, editor.HasSelection()))
+            editor.Copy();
+        if (ImGui::MenuItem("Cut", "Ctrl-X", nullptr, !readOnly && editor.HasSelection()))
+            editor.Cut();
+        if (ImGui::MenuItem("Delete", "Del", nullptr, !readOnly && editor.HasSelection()))
+            editor.Delete();
+        if (ImGui::MenuItem("Paste", "Ctrl-V", nullptr, !readOnly && ImGui::GetClipboardText() != nullptr))
+            editor.Paste();
+
+        ImGui::Separator();
+
+        if (ImGui::MenuItem("Select all"))
+            editor.SetSelection(TextEditor::Coordinates(), TextEditor::Coordinates(editor.GetTotalLines(), 0));
+
+        ImGui::EndMenu();
+    }
+
+    if (ImGui::BeginMenu("View")) {
+        if (ImGui::MenuItem("Dark palette"))
+            editor.SetPalette(TextEditor::GetDarkPalette());
+        if (ImGui::MenuItem("Light palette"))
+            editor.SetPalette(TextEditor::GetLightPalette());
+        if (ImGui::MenuItem("Retro blue palette"))
+            editor.SetPalette(TextEditor::GetRetroBluePalette());
+        if (ImGui::MenuItem("Custom palette"))
+            editor.SetPalette(customPalette);
+        ImGui::EndMenu();
+    }
+    ImGui::EndMenuBar();
+}
+
+ImGui::Text("%6d/%-6d %6d lines  | %s | %s | %s | %s", cpos.mLine + 1, cpos.mColumn + 1, editor.GetTotalLines(),
+            editor.IsOverwrite() ? "Ovr" : "Ins",
+            editor.CanUndo() ? "*" : " ",
+            editor.GetLanguageDefinition().mName.c_str(), cj_config.path.c_str());
+
+editor.Render("TextEditor");
+ImGui::End();
+
+ImGui::Begin("##basement", NULL,
+    ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
+    ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar);
+{
+    if (ImGui::Button("Validate")) {
+        JsonSax json_sax;
+        const std::string text = editor.GetText();
+        json::sax_parse(text, &json_sax);
+
+        TextEditor::ErrorMarkers markers;
+        for (const auto& err : json_sax.errors) {
+            int line = std::count(text.begin(), text.begin() + err.first, '\n');
+            markers.insert({line, err.second});
+        }
+        editor.SetErrorMarkers(markers);
+    }
+
+    ImGui::SameLine();
+
+    if (ImGui::Button("Copy")) {
+        const std::string text = editor.GetText();
+        ImGui::SetClipboardText(text.c_str());
+    }
+}
+ImGui::End();
+```
+
 # Main features
  - approximates typical code editor look and feel (essential mouse/keyboard commands work - I mean, the commands _I_ normally use :))
  - undo/redo


### PR DESCRIPTION
## Summary
- add a comprehensive JSON editor example with English comments
- show how to configure a custom color palette

## Testing
- `make test` (fails: No rule to make target 'test')
- `make` (fails: No targets specified and no makefile found)

------
https://chatgpt.com/codex/tasks/task_e_68b52c3369e8832c9838b4eecdb158b5