### PR TITLE
Move palette and shortcut helpers to namespace

### DIFF
--- a/ImGuiColorTextEdit.cpp
+++ b/ImGuiColorTextEdit.cpp
@@ -150,7 +150,7 @@ TextEditor::TextEditor()
     m_shortcuts = GetDefaultShortcuts();
 }
 
-const std::vector<Shortcut> TextEditor::GetDefaultShortcuts()
+const std::vector<Shortcut> GetDefaultShortcuts()
 {
         std::vector<Shortcut> ret;
         ret.resize((int)ShortcutID::Count);
@@ -1458,23 +1458,23 @@ void TextEditor::HandleKeyboardInputs()
                 case ShortcutID::Replace: mFindOpened = mHasSearch; mFindJustOpened = mHasSearch; mReplaceOpened = mHasSearch; break;
                 case ShortcutID::DebugStep:
                     if (OnDebuggerAction)
-                        OnDebuggerAction(this, TextEditor::DebugAction::Step);
+                        OnDebuggerAction(this, DebugAction::Step);
                 break;
                 case ShortcutID::DebugStepInto:
                     if (OnDebuggerAction)
-                        OnDebuggerAction(this, TextEditor::DebugAction::StepInto);
+                        OnDebuggerAction(this, DebugAction::StepInto);
                 break;
                 case ShortcutID::DebugStepOut:
                     if (OnDebuggerAction)
-                        OnDebuggerAction(this, TextEditor::DebugAction::StepOut);
+                        OnDebuggerAction(this, DebugAction::StepOut);
                 break;
                 case ShortcutID::DebugContinue:
                     if (OnDebuggerAction)
-                        OnDebuggerAction(this, TextEditor::DebugAction::Continue);
+                        OnDebuggerAction(this, DebugAction::Continue);
                 break;
                 case ShortcutID::DebugStop:
                     if (OnDebuggerAction)
-                        OnDebuggerAction(this, TextEditor::DebugAction::Stop);
+                        OnDebuggerAction(this, DebugAction::Stop);
                 break;
                 case ShortcutID::DebugJumpHere:
                     if (OnDebuggerJump)
@@ -3706,23 +3706,23 @@ void TextEditor::Render(const char* aTitle, const ImVec2& aSize, bool aBorder)
         ImVec2 dbBarStart = ImGui::GetCursorPos();
 
         if (ImGui::Button(("Step##ted_dbgstep" + std::string(aTitle)).c_str()) && OnDebuggerAction)
-            OnDebuggerAction(this, TextEditor::DebugAction::Step);
+            OnDebuggerAction(this, DebugAction::Step);
         ImGui::SameLine(0, 6);
 
         if (ImGui::Button(("Step In##ted_dbgstepin" + std::string(aTitle)).c_str()) && OnDebuggerAction)
-            OnDebuggerAction(this, TextEditor::DebugAction::StepInto);
+            OnDebuggerAction(this, DebugAction::StepInto);
         ImGui::SameLine(0, 6);
 
         if (ImGui::Button(("Step Out##ted_dbgstepout" + std::string(aTitle)).c_str()) && OnDebuggerAction)
-            OnDebuggerAction(this, TextEditor::DebugAction::StepOut);
+            OnDebuggerAction(this, DebugAction::StepOut);
         ImGui::SameLine(0, 6);
 
         if (ImGui::Button(("Continue##ted_dbgcontinue" + std::string(aTitle)).c_str()) && OnDebuggerAction)
-            OnDebuggerAction(this, TextEditor::DebugAction::Continue);
+            OnDebuggerAction(this, DebugAction::Continue);
         ImGui::SameLine(0, 6);
 
         if (ImGui::Button(("Stop##ted_dbgstop" + std::string(aTitle)).c_str()) && OnDebuggerAction)
-            OnDebuggerAction(this, TextEditor::DebugAction::Stop);
+            OnDebuggerAction(this, DebugAction::Stop);
 
         ImVec2 dbBarEnd = ImGui::GetCursorPos();
         mDebugBarHeight = dbBarEnd.y - dbBarStart.y + ImGui::GetStyle().WindowPadding.y * 2.0f;
@@ -5149,7 +5149,7 @@ std::vector<std::string> TextEditor::GetRelevantExpressions(int line)
     return ret;
 }
 
-const TextEditor::Palette & TextEditor::GetDarkPalette()
+const TextEditor::Palette & GetDarkPalette()
 {
     const static Palette p = { {
         0xff7f7f7f, // Default
@@ -5188,7 +5188,7 @@ const TextEditor::Palette & TextEditor::GetDarkPalette()
     return p;
 }
 
-const TextEditor::Palette & TextEditor::GetLightPalette()
+const TextEditor::Palette & GetLightPalette()
 {
     const static Palette p = { {
         0xff7f7f7f, // None
@@ -5227,7 +5227,7 @@ const TextEditor::Palette & TextEditor::GetLightPalette()
     return p;
 }
 
-const TextEditor::Palette & TextEditor::GetRetroBluePalette()
+const TextEditor::Palette & GetRetroBluePalette()
 {
     const static Palette p = { {
         0xff00ffff, // None

--- a/ImGuiColorTextEdit.h
+++ b/ImGuiColorTextEdit.h
@@ -259,6 +259,15 @@ namespace ImTextEdit {
     const LanguageDefinition& JSONC();
     const LanguageDefinition& JSONWithHash();
 
+    enum class DebugAction
+    {
+        Step,
+        StepInto,
+        StepOut,
+        Continue,
+        Stop
+    };
+
 /// \brief Interactive text editor with syntax highlighting for ImGui.
 /// \note Right-to-left scripts and complex text shaping are not supported.
 class TextEditor {
@@ -505,25 +514,6 @@ public:
         mACEntrySearch.push_back(search);
         mACEntries.push_back(std::make_pair(display, value));
     }
-
-    /// \brief Retrieve default keyboard shortcuts.
-    static const std::vector<Shortcut> GetDefaultShortcuts();
-    /// \brief Get built-in dark color palette.
-    static const Palette& GetDarkPalette();
-    /// \brief Get built-in light color palette.
-    static const Palette& GetLightPalette();
-    /// \brief Get built-in retro blue color palette.
-    static const Palette& GetRetroBluePalette();
-
-    enum class DebugAction
-    {
-        Step,
-        StepInto,
-        StepOut,
-        Continue,
-        Stop
-    };
-
     std::function<void(TextEditor*, int)> OnDebuggerJump;
     std::function<void(TextEditor*, DebugAction)> OnDebuggerAction;
     std::function<void(TextEditor*, const std::string&)> OnIdentifierHover;
@@ -771,5 +761,14 @@ private:
 
     float mLastClick;
 };
+
+/// \brief Retrieve default keyboard shortcuts.
+const std::vector<Shortcut> GetDefaultShortcuts();
+/// \brief Get built-in dark color palette.
+const TextEditor::Palette& GetDarkPalette();
+/// \brief Get built-in light color palette.
+const TextEditor::Palette& GetLightPalette();
+/// \brief Get built-in retro blue color palette.
+const TextEditor::Palette& GetRetroBluePalette();
 
 } // namespace ImTextEdit

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ auto lang = ImTextEdit::JSON();
 editor.SetLanguageDefinition(lang);
 
 // Optional: create a custom color palette based on the dark theme
-ImTextEdit::TextEditor::Palette customPalette = ImTextEdit::TextEditor::GetDarkPalette();
+ImTextEdit::TextEditor::Palette customPalette = ImTextEdit::GetDarkPalette();
 customPalette[(int)ImTextEdit::PaletteIndex::Keyword] = ImVec4(0.86f, 0.40f, 0.24f, 1.0f); // keywords
 customPalette[(int)ImTextEdit::PaletteIndex::String]  = ImVec4(0.90f, 0.76f, 0.18f, 1.0f); // strings
 editor.SetPalette(customPalette);
@@ -109,11 +109,11 @@ editor.SetSelection(ImTextEdit::Coordinates(), ImTextEdit::Coordinates(editor.Ge
 
     if (ImGui::BeginMenu("View")) {
         if (ImGui::MenuItem("Dark palette"))
-            editor.SetPalette(ImTextEdit::TextEditor::GetDarkPalette());
+            editor.SetPalette(ImTextEdit::GetDarkPalette());
         if (ImGui::MenuItem("Light palette"))
-            editor.SetPalette(ImTextEdit::TextEditor::GetLightPalette());
+            editor.SetPalette(ImTextEdit::GetLightPalette());
         if (ImGui::MenuItem("Retro blue palette"))
-            editor.SetPalette(ImTextEdit::TextEditor::GetRetroBluePalette());
+            editor.SetPalette(ImTextEdit::GetRetroBluePalette());
         if (ImGui::MenuItem("Custom palette"))
             editor.SetPalette(customPalette);
         ImGui::EndMenu();


### PR DESCRIPTION
## Summary
- expose debug actions and palette/shortcut helpers at `ImTextEdit` namespace level
- update references to use namespace functions

## Testing
- `g++ -std=c++17 -c ImGuiColorTextEdit.cpp` *(fails: imgui.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b53f75cf74832cab5fd616823c561a