### PR TITLE
Extract invalid coordinate helper to namespace

### DIFF
--- a/ImGuiColorTextEdit.h
+++ b/ImGuiColorTextEdit.h
@@ -36,11 +36,6 @@ namespace ImTextEdit {
             assert(aLine >= 0);
             assert(aColumn >= 0);
         }
-        static Coordinates Invalid()
-        {
-            static Coordinates invalid(-1, -1);
-            return invalid;
-        }
 
         bool operator==(const Coordinates& o) const
         {
@@ -80,6 +75,12 @@ namespace ImTextEdit {
             return mColumn >= o.mColumn;
         }
     };
+
+    inline Coordinates Invalid()
+    {
+        static Coordinates invalid(-1, -1);
+        return invalid;
+    }
 
     struct Identifier {
         Identifier() {}


### PR DESCRIPTION
## Summary
- move invalid coordinate helper out of Coordinates struct into ImTextEdit namespace

## Testing
- `g++ -std=c++17 -c ImGuiColorTextEdit/ImGuiColorTextEdit.cpp -IImGuiColorTextEdit -I/usr/include/imgui` (fails: Palette does not name a type)


------
https://chatgpt.com/codex/tasks/task_e_68b541d95c84832c8064911bf04acb16